### PR TITLE
drop tests support on Drupal <= 9.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,13 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.3', '9.4', '9.5', '10.0']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '11.0']
         module: ['loco_translate']
         experimental: [ false ]
+        include:
+          - drupal_version: '11.0'
+            module: 'loco_translate'
+            experimental: true
 
     steps:
       - uses: actions/checkout@v3
@@ -38,9 +42,13 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.3', '9.4', '9.5', '10.0']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '11.0']
         module: [ 'loco_translate' ]
         experimental: [ false ]
+        include:
+          - drupal_version: '11.0'
+            module: 'loco_translate'
+            experimental: true
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -9,10 +9,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.3'
+          php-version: '8.1'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
-          tools: cs2pr, composer:v1
-      - uses: actions/checkout@v3
+          tools: cs2pr, composer:v2
+      - uses: actions/checkout@v4
       - run: composer install --prefer-dist
       - run: ./vendor/bin/phpcs ./ --report=checkstyle | cs2pr
 
@@ -23,10 +23,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.3'
+          php-version: '8.1'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
-          tools: cs2pr, composer:v1, phpmd
-      - uses: actions/checkout@v3
+          tools: cs2pr, composer:v2, phpmd
+      - uses: actions/checkout@v4
       - run: composer install --prefer-dist
       - run: phpmd ./ text ./phpmd.xml --suffixes php,module,inc,install,test,profile,theme,css,info,txt --exclude *Test.php,*vendor/*
 
@@ -37,10 +37,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.3'
+          php-version: '8.1'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
-          tools: cs2pr, composer:v1, phpcpd
-      - uses: actions/checkout@v3
+          tools: cs2pr, composer:v2, phpcpd
+      - uses: actions/checkout@v4
       - run: composer install --prefer-dist
       - run: phpcpd ./src --suffix .php --suffix .module --suffix .inc --suffix .install --suffix .test --suffix .profile --suffix .theme --suffix .css --suffix .info --suffix .txt --exclude *.md --exclude *.info.yml --exclude tests --exclude vendor/
 
@@ -48,7 +48,7 @@ jobs:
     name: PhpDeprecationDetector (phpdd)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker-compose -f docker-compose.yml pull --include-deps drupal
       - name: Build the docker-compose stack
         run: docker-compose -f docker-compose.yml build drupal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - add Drupal GitlabCI
+- add coverage of Drupal 10.2.x
+- add coverage of Drupal 11.0-dev
+
+### Removed
+- drop tests support on Drupal <= 9.4
 
 ## [3.0.0] - 2022-11-18
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,22 +25,22 @@ First of all, you will need to have the following tools installed
 globally on your environment:
 
   * drush
-  * Latest dev release of Drupal 9.x/10.x.
+  * Latest dev release of Drupal 9.x/10.x/11.x.
   * docker
-  * docker-compose
+  * docker compose
 
 ### Project bootstrap
 
 Once run, you will be able to access to your fresh installed Drupal on `localhost::8888`.
 
-    docker-compose build --pull --build-arg BASE_IMAGE_TAG=9.3 drupal
+    docker compose build --pull --build-arg BASE_IMAGE_TAG=10.1 drupal
     (get a coffee, this will take some time...)
-    docker-compose up -d drupal
-    docker-compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" --site-name=Example -y
+    docker compose up -d drupal
+    docker compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" --site-name=Example -y
 
     # You may be interesed by reseting the admin passowrd of your Docker and install the module using those cmd.
-    docker-compose exec drupal drush user:password admin admin
-    docker-compose exec drupal drush en loco_translate
+    docker compose exec drupal drush user:password admin admin
+    docker compose exec drupal drush en loco_translate
 
 ## 🏆 Tests
 
@@ -48,7 +48,7 @@ We use the [Docker for Drupal Contrib images](https://hub.docker.com/r/wengerk/d
 
 Run testing by stopping at first failure using the following command:
 
-    docker-compose exec -u www-data drupal phpunit --group=loco_translate --no-coverage --stop-on-failure --configuration=/var/www/html/phpunit.xml
+    docker compose exec -u www-data drupal phpunit --group=loco_translate --no-coverage --stop-on-failure --configuration=/var/www/html/phpunit.xml
 
 ## 🚔 Check Drupal coding standards & Drupal best practices
 
@@ -66,7 +66,7 @@ The following Analyzer will be downloaded & installed as PHAR:
 
     ./scripts/hooks/post-commit
     # or run command on the container itself
-    docker-compose exec drupal bash
+    docker compose exec drupal bash
 
 #### Running Code Sniffer Drupal & DrupalPractice
 
@@ -78,13 +78,13 @@ violations.
 PHP_CodeSniffer is an essential development tool that ensures your code remains clean and consistent.
 
   ```
-  $ docker-compose exec drupal ./vendor/bin/phpcs ./web/modules/contrib/loco_translate/
+  $ docker compose exec drupal ./vendor/bin/phpcs ./web/modules/contrib/loco_translate/
   ```
 
 Automatically fix coding standards
 
   ```
-  $ docker-compose exec drupal ./vendor/bin/phpcbf ./web/modules/contrib/loco_translate/
+  $ docker compose exec drupal ./vendor/bin/phpcbf ./web/modules/contrib/loco_translate/
   ```
 
 #### Running PHP Mess Detector
@@ -94,7 +94,7 @@ https://github.com/phpmd/phpmd
 Detect overcomplicated expressions & Unused parameters, methods, properties.
 
   ```
-  $ docker-compose exec drupal phpmd ./web/modules/contrib/loco_translate/ text ./phpmd.xml \
+  $ docker compose exec drupal phpmd ./web/modules/contrib/loco_translate/ text ./phpmd.xml \
   --suffixes php,module,inc,install,test,profile,theme,css,info,txt --exclude *Test.php,*vendor/*
   ```
 
@@ -105,7 +105,7 @@ https://github.com/sebastianbergmann/phpcpd
 `phpcpd` is a Copy/Paste Detector (CPD) for PHP code.
 
   ```
-  $ docker-compose exec drupal phpcpd ./web/modules/contrib/loco_translate/src --suffix .php --suffix .module --suffix .inc --suffix .install --suffix .test --suffix .profile --suffix .theme --suffix .css --suffix .info --suffix .txt --exclude *.md --exclude *.info.yml --exclude tests --exclude vendor/
+  $ docker compose exec drupal phpcpd ./web/modules/contrib/loco_translate/src --suffix .php --suffix .module --suffix .inc --suffix .install --suffix .test --suffix .profile --suffix .theme --suffix .css --suffix .info --suffix .txt --exclude *.md --exclude *.info.yml --exclude tests --exclude vendor/
   ```
 
 #### Running PhpDeprecationDetector
@@ -115,7 +115,7 @@ https://github.com/wapmorgan/PhpDeprecationDetector
 A scanner that checks compatibility of your code with PHP interpreter versions.
 
   ```
-  $ docker-compose exec drupal phpdd ./web/modules/contrib/loco_translate/ \
+  $ docker compose exec drupal phpdd ./web/modules/contrib/loco_translate/ \
     --file-extensions php,module,inc,install,test,profile,theme,info --exclude vendor
   ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 ARG BASE_IMAGE_TAG=9.3
 FROM wengerk/drupal-for-contrib:${BASE_IMAGE_TAG}
 
-# Disable deprecation notice.
-# ENV SYMFONY_DEPRECATIONS_HELPER=disabled
+# Disable deprecation notice since PHPUnit 10 with Drupal 10.2 and upper.
+# @see https://www.drupal.org/project/drupal/issues/3403491
+ENV SYMFONY_DEPRECATIONS_HELPER=weak
 
 ENV COMPOSER_MEMORY_LIMIT=-1
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ TBD
 
 ## Versions
 
-This module works on Drupal 8, Drupal 9 & Drupal 10 !
+This module works on Drupal 8, Drupal 9, Drupal 10 & Drupal 11 (dev) !
 
-The latest version should work with all Drupal 9/10 releases using Drush 10+,
+The latest version should work with all Drupal 9/10/11 releases using Drush 10+,
 and it is always recommended keeping Drupal core installations up to date.
 
 ## Which version should I use?
@@ -47,6 +47,7 @@ and it is always recommended keeping Drupal core installations up to date.
 |    8.8.x    |      2.1       |
 |     9.x     |      2.x       |
 |    10.x     |     3.0.x      |
+|   11.x-dev   |     3.0.x      |
 
 ## Dependencies
 
@@ -68,16 +69,6 @@ We highly recommend you to install the module using `composer`.
 
   ```bash
   composer require drupal/loco_translate
-  ```
-
-You can also install it using the `drush` or `drupal console` cli.
-
-  ```bash
-  drush dl loco_translate
-  ```
-
-  ```bash
-  drupal module:install loco_translate
   ```
 
 Configure your API Keys - as required by Loco - by adding the following code in your `settings.php`

--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,10 @@
   },
   "require": {
     "loco/loco": "^2.0"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     restart: always
 
   db:
-    image: mariadb:10.3.7
+    image: mariadb:10.3.8
     environment:
       MYSQL_USER: drupal
       MYSQL_PASSWORD: drupal

--- a/loco_translate.info.yml
+++ b/loco_translate.info.yml
@@ -2,7 +2,7 @@ name: Loco Translate
 description: 'Loco Translate provides a normalised way to collect & gather internationalisation assets & translations into & from Loco.'
 package: Multilingual
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.5 || ^10 || ^11
 dependencies:
   - drupal:locale
   - drupal:language


### PR DESCRIPTION
### 💬 Description
- drop tests support on Drupal <= 9.4
- add coverage of Drupal 10.2.x
- add coverage of Drupal 11.0-dev