### PR TITLE
add official support of drupal 11.1

### DIFF
--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -49,3 +49,4 @@ unusedcode
 voitures
 wapmorgan
 wengerk
+montag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '11.0']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['loco_translate']
         experimental: [ false ]
         include:
-          - drupal_version: '11.1'
+          - drupal_version: '11.2'
             module: 'loco_translate'
             experimental: true
 
@@ -42,11 +42,11 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '11.0']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: [ 'loco_translate' ]
         experimental: [ false ]
         include:
-          - drupal_version: '11.1'
+          - drupal_version: '11.2'
             module: 'loco_translate'
             experimental: true
 
@@ -75,7 +75,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5']
+        drupal_version: ['10.4']
         module: ['loco_translate']
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add official support of drupal 11.1
 
 ## [3.0.2] - 2024-08-20
 ### Changed


### PR DESCRIPTION
### 💬 Description
add official support of drupal 11.1

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
