### PR TITLE
replace deprecated constant REQUIREMENT_ERROR by RequirementSeverity::Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- replace deprecated constant REQUIREMENT_ERROR by RequirementSeverity::Error
 
 ## [3.0.3] - 2025-05-15
 ### Added

--- a/loco_translate.install
+++ b/loco_translate.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Url;
+use Drupal\Core\Requirement\RequirementSeverity;
 
 /**
  * Implements hook_install().
@@ -34,7 +35,7 @@ function loco_translate_requirements($phase) {
     $requirements['loco_translate_loco_sdk'] = [
       'title' => t('Loco libraries'),
       'value' => t('Missing libraries'),
-      'severity' => REQUIREMENT_ERROR,
+      'severity' => class_exists('Drupal\Core\Requirement\RequirementSeverity') ? RequirementSeverity::Error : REQUIREMENT_ERROR,
       'description' => t('Loco Translate requires the <a href=":sdk-url" target="_blank">external Loco SDK</a>. The recommended way of solving this dependency is using <a href=":composer-url" target="_blank">Composer</a> running the following from the command line: <br /><code>composer require loco/loco:^2.0</code>', [
         ':sdk-url' => 'https://github.com/loco/loco-php-sdk',
         ':composer-url' => 'https://getcomposer.org',
@@ -48,7 +49,7 @@ function loco_translate_requirements($phase) {
       $requirements['loco_translate_readonly_key'] = [
         'title' => t('Loco Export API key'),
         'value' => t('Missing'),
-        'severity' => REQUIREMENT_ERROR,
+        'severity' => class_exists('Drupal\Core\Requirement\RequirementSeverity') ? RequirementSeverity::Error : REQUIREMENT_ERROR,
         'description' => t('Loco Translate requires your Export API key. Keep this key secret by adding it in your <code>settings.php</code> or fill the <a href=":settings-url">Settings form</a>. You may find more informations about API keys on <a href=":loco-url" target="_blank">Loco support</a> pages', [
           ':loco-url' => 'https://localise.biz/help/developers/api-keys',
           ':settings-url' => Url::fromRoute('loco_translate.settings', [], ['fragment' => 'edit-api'])->toString(),
@@ -60,7 +61,7 @@ function loco_translate_requirements($phase) {
       $requirements['loco_translate_fullaccess_key'] = [
         'title' => t('Loco Full Access API key'),
         'value' => t('Missing'),
-        'severity' => REQUIREMENT_ERROR,
+        'severity' => class_exists('Drupal\Core\Requirement\RequirementSeverity') ? RequirementSeverity::Error : REQUIREMENT_ERROR,
         'description' => t('Loco Translate requires your Full Access API key. Keep this key secret by adding it in your <code>settings.php</code> or fill the <a href="">Settings form</a>. You may find more informations about API keys on <a href=":loco-url" target="_blank">Loco support</a> pages', [
           ':loco-url' => 'https://localise.biz/help/developers/api-keys',
           ':settings-url' => Url::fromRoute('loco_translate.settings', [], ['fragment' => 'edit-api'])->toString(),

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,5 @@ parameters:
   ignoreErrors:
     # new static() is a best practice in Drupal, so we cannot fix that.
     - "#^Unsafe usage of new static#"
+    # The module support Drupal 10 and Drupal 11, so we cannot fix that deprecation without dropping support below Drupal 11.2.
+    - "#^Fetching deprecated class constant REQUIREMENT_ERROR#"


### PR DESCRIPTION
### 💬 Description
replace deprecated constant REQUIREMENT_ERROR by RequirementSeverity::Error

### 🎟️ Issue(s)

```
 ------ ---------------------------------------------------------------- 
  Line   src/Controller/OverviewController.php                           
 ------ ---------------------------------------------------------------- 
  128    Fetching deprecated class constant REQUIREMENT_ERROR of class   
         Drupal\system\SystemManager:                                    
         in drupal:11.2.0 and is removed from drupal:12.0.0. Use         
          \Drupal\Core\Extension\Requirement\RequirementSeverity::Error  
         instead.                                                        
         🪪 classConstant.deprecated                                     
  142    Fetching deprecated class constant REQUIREMENT_ERROR of class   
         Drupal\system\SystemManager:                                    
         in drupal:11.2.0 and is removed from drupal:12.0.0. Use         
          \Drupal\Core\Extension\Requirement\RequirementSeverity::Error  
         instead.                                                        
         🪪 classConstant.deprecated                                     
  155    Fetching deprecated class constant REQUIREMENT_ERROR of class   
         Drupal\system\SystemManager:                                    
         in drupal:11.2.0 and is removed from drupal:12.0.0. Use         
          \Drupal\Core\Extension\Requirement\RequirementSeverity::Error  
         instead.                                                        
         🪪 classConstant.deprecated                                     
 ------ ---------------------------------------------------------------- 
```

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
