### PR TITLE
drop support of older that Drupal 10.5 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.5', '11.0', '11.1', '11.2']
         module: ['loco_translate']
         experimental: [ false ]
         include:
-          - drupal_version: '11.2'
+          - drupal_version: '10.6'
+            module: 'loco_translate'
+            experimental: true
+          - drupal_version: '11.3'
             module: 'loco_translate'
             experimental: true
 
@@ -42,11 +45,14 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.5', '11.0', '11.1', '11.2']
         module: [ 'loco_translate' ]
         experimental: [ false ]
         include:
-          - drupal_version: '11.2'
+          - drupal_version: '10.6'
+            module: 'loco_translate'
+            experimental: true
+          - drupal_version: '11.3'
             module: 'loco_translate'
             experimental: true
 
@@ -75,7 +81,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.4']
+        drupal_version: ['10.5']
         module: ['loco_translate']
 
     steps:

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2
       - uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2, phpmd
       - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2, phpcpd
       - uses: actions/checkout@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,12 +32,13 @@ variables:
   SKIP_ESLINT: '1'
   # Opt in to testing current minor against max supported PHP version.
   OPT_IN_TEST_MAX_PHP: '1'
-  # Opt in to testing previous minor (Drupal 11.0.3) & next minor (Drupal 11.2-dev).
+  # Opt in to testing previous minor (Drupal 11.1.x)
   OPT_IN_TEST_PREVIOUS_MINOR: '1'
+  # Opt in to testing next minor (Drupal 11.3.x).
   OPT_IN_TEST_NEXT_MINOR: '1'
-  # Opt in to testing $CORE_PREVIOUS_MAJOR (currently Drupal 10.4.6).
+  # Opt in to testing $CORE_PREVIOUS_MAJOR (Drupal 10.4.x).
   OPT_IN_TEST_PREVIOUS_MAJOR: '1'
-  # Opt in to testing $CORE_MAJOR_DEVELOPMENT (currently Drupal 12).
+  # Opt in to testing $CORE_MAJOR_DEVELOPMENT (Drupal 12).
   OPT_IN_TEST_NEXT_MAJOR: '1'
 
 # This module wants to strictly comply with Drupal's coding standards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - replace deprecated constant REQUIREMENT_ERROR by RequirementSeverity::Error
 - fix division by zero when using a key for a brand new project with no assets in it - #3537439
 
+### Added
+- add official support of drupal 10.5
+- add official support of drupal 11.2
+
+### Removed
+- drop coverage of Drupal 10.0.x
+- drop coverage of Drupal 10.1.x
+- drop coverage of Drupal 10.2.x
+- drop coverage of Drupal 10.3.x
+- drop coverage of Drupal 10.4.x
+
 ## [3.0.3] - 2025-05-15
 ### Added
 - add official support of drupal 11.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ globally on your environment:
 
 Once run, you will be able to access to your fresh installed Drupal on `localhost::8888`.
 
-    docker compose build --pull --build-arg BASE_IMAGE_TAG=10.5 drupal
+    docker compose build --pull --build-arg BASE_IMAGE_TAG=11.2 drupal
     (get a coffee, this will take some time...)
     docker compose up -d drupal
     docker compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" --site-name=Example -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_TAG=10.5
+ARG BASE_IMAGE_TAG=11.2
 FROM wengerk/drupal-for-contrib:${BASE_IMAGE_TAG}
 
 # Disable deprecation notice since PHPUnit 10 with Drupal 10.2 and upper.

--- a/loco_translate.info.yml
+++ b/loco_translate.info.yml
@@ -2,7 +2,7 @@ name: Loco Translate
 description: 'Loco Translate provides a normalised way to collect & gather internationalisation assets & translations into & from Loco.'
 package: Multilingual
 type: module
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.5 || ^11
 dependencies:
   - drupal:locale
   - drupal:language

--- a/tests/modules/loco_translate_test/loco_translate_test.info.yml
+++ b/tests/modules/loco_translate_test/loco_translate_test.info.yml
@@ -2,7 +2,7 @@ name: Loco Translate test
 description: Support module for Loco Translate testing.
 package: Testing
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^10.5 || ^11
 
 dependencies:
   - drupal:loco_translate


### PR DESCRIPTION
### 💬 Description
drop support of older that Drupal 10.5 version

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
