### PR TITLE
add official support of drupal 10.6 & 11.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,16 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.5', '11.0', '11.1', '11.2']
+        drupal_version: ['10.5', '10.6' '11.0', '11.1', '11.2', '11.3']
         module: ['loco_translate']
         experimental: [ false ]
-        include:
-          - drupal_version: '10.6'
-            module: 'loco_translate'
-            experimental: true
-          - drupal_version: '11.3'
-            module: 'loco_translate'
-            experimental: true
+#         include:
+#           - drupal_version: '10.6'
+#             module: 'loco_translate'
+#             experimental: true
+#           - drupal_version: '11.3'
+#             module: 'loco_translate'
+#             experimental: true
 
     steps:
       - uses: actions/checkout@v6
@@ -45,16 +45,16 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.5', '11.0', '11.1', '11.2']
+        drupal_version: ['10.5', '10.6' '11.0', '11.1', '11.2', '11.3']
         module: [ 'loco_translate' ]
         experimental: [ false ]
-        include:
-          - drupal_version: '10.6'
-            module: 'loco_translate'
-            experimental: true
-          - drupal_version: '11.3'
-            module: 'loco_translate'
-            experimental: true
+#         include:
+#           - drupal_version: '10.6'
+#             module: 'loco_translate'
+#             experimental: true
+#           - drupal_version: '11.3'
+#             module: 'loco_translate'
+#             experimental: true
 
     steps:
       - uses: actions/checkout@v6
@@ -81,7 +81,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.5']
+        drupal_version: ['10.6']
         module: ['loco_translate']
 
     steps:

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2
       - uses: actions/checkout@v6
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2, phpmd
       - uses: actions/checkout@v6
@@ -37,7 +37,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2, phpcpd
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add official support of drupal 10.6
+- add official support of drupal 11.3
 
 ## [3.0.4] - 2025-08-25
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add official support of drupal 10.6
 - add official support of drupal 11.3
 
+### Changed
+- remove deprecated usage of FileSystemInterface::basename
+
 ## [3.0.4] - 2025-08-25
 ### Fixed
 - replace deprecated constant REQUIREMENT_ERROR by RequirementSeverity::Error

--- a/loco_translate.install
+++ b/loco_translate.install
@@ -5,8 +5,8 @@
  * Contains loco_translate.install.
  */
 
-use Drupal\Core\Url;
 use Drupal\Core\Requirement\RequirementSeverity;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_install().

--- a/loco_translate.services.yml
+++ b/loco_translate.services.yml
@@ -21,7 +21,6 @@ services:
     arguments:
       - '@loco_translate.utility'
       - '@module_handler'
-      - '@file_system'
 
   loco_translate.loco_api.push:
     class: \Drupal\loco_translate\Loco\Push

--- a/src/TranslationsImport.php
+++ b/src/TranslationsImport.php
@@ -3,7 +3,6 @@
 namespace Drupal\loco_translate;
 
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\File\FileSystemInterface;
 use Drupal\locale\Gettext;
 use Drupal\loco_translate\Exception\LocoTranslateException;
 
@@ -27,26 +26,16 @@ class TranslationsImport {
   protected $moduleHandler;
 
   /**
-   * The file system service.
-   *
-   * @var \Drupal\Core\File\FileSystemInterface
-   */
-  protected $fileSystem;
-
-  /**
    * Class constructor.
    *
    * @param \Drupal\loco_translate\Utility $utility
    *   Utility methods for Loco Translate.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler service.
-   * @param \Drupal\Core\File\FileSystemInterface $file_system
-   *   The file system service.
    */
-  public function __construct(Utility $utility, ModuleHandlerInterface $module_handler, FileSystemInterface $file_system) {
+  public function __construct(Utility $utility, ModuleHandlerInterface $module_handler) {
     $this->utility = $utility;
     $this->moduleHandler = $module_handler;
-    $this->fileSystem = $file_system;
   }
 
   /**
@@ -90,7 +79,7 @@ class TranslationsImport {
 
     // Create a valid file class for Gettext::fileToDatabase.
     $file            = new \stdClass();
-    $file->filename  = $this->fileSystem->basename($path);
+    $file->filename  = basename($path);
     $file->uri       = $path;
     $file->langcode  = $locale;
     $file->timestamp = filemtime($path);


### PR DESCRIPTION
### 💬 Description
add official support of drupal 10.6 & 11.3

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
